### PR TITLE
reuse DynamicVectors and recurse in parallel

### DIFF
--- a/mojo/fft-mojo.mojo
+++ b/mojo/fft-mojo.mojo
@@ -42,33 +42,32 @@ fn to_str( vec: DynamicVector[FieldElement] ) -> String:
 #=============================================================================
 # Implementation of Cooley-Tukey FFT over Finite Field
 
-fn half_vector( vec: DynamicVector[FieldElement], start: Int ) -> DynamicVector[FieldElement]:
-    var result = make_vector( len(vec) // 2 )
-    debug_assert( start + (len(result)-1) * 2 < len(vec), "out of bounds" )
-    for i in range(len(result)):
+fn half_vector( vec: DynamicVector[FieldElement], start: Int, size: Int ) -> DynamicVector[FieldElement]:
+    var result = make_vector( size )
+    let half_size = size // 2
+    debug_assert( start + 1 + (half_size-1) * 2 < size, "out of bounds" )
+    for i in range(half_size):
         result[i] = vec[start + i*2]
+        result[i + half_size] = vec[start + i*2 + 1]
     return result
 
-fn fft_over_finite_field( P: DynamicVector[FieldElement], w: FieldElement ) \
-                        -> DynamicVector[FieldElement]:
-    let n = len(P)
-    if n == 1:
-        return P
+fn fft_over_finite_field( inout P: DynamicVector[FieldElement], offset: Int, size: Int, w: FieldElement ):
+    if size == 1:
+        return
 
     let w_square = w * w
-    let Pe = half_vector( P, 0 )
-    let Po = half_vector( P, 1 )
-    let ye = fft_over_finite_field( Pe, w_square )
-    let yo = fft_over_finite_field( Po, w_square )
-    var y = make_vector( n )
+    var P_ = half_vector( P, 0, size )
+    let half_size = size // 2
+    fft_over_finite_field( P_, 0, half_size, w_square )
+    fft_over_finite_field( P_, half_size, half_size, w_square )
+    
     var w_power = FieldElement(1)
-    for j in range(n // 2):
-        let u = ye[j]
-        let v = (w_power * yo[j])
-        y[j] = u + v
-        y[j + n // 2] = u - v
+    for j in range(half_size):
+        let u = P_[j]
+        let v = (w_power * P_[half_size + j])
+        P[j] = u + v
+        P[j + half_size] = u - v
         w_power = w_power * w
-    return y
 
 
 #=============================================================================
@@ -90,7 +89,7 @@ fn main() raises:
 
     @parameter
     fn bench():
-        _ = fft_over_finite_field( values, g )
+        _ = fft_over_finite_field( values, 0, size, g )
 
     let report = benchmark.run[bench]( 1, 3, 4, 10 )
     print( "mean runtime:", report.mean("s") )


### PR DESCRIPTION
After seeing your project on Discord I ended up running the code through a profiler.  Most of the time was being spent allocating the DynamicVectors.  So I made a couple changes based off that.

- reuse DynamicVectors.  Now they are only created in the initial values and when `half_vector` is called.  To reuse appropriately an offset and size need to be passed around with the vector.  When lifetimes are done and vector slices can be worked with the code can be simplified.
- fuse the two calls to `half_vector`.  Calling a single for loop that reads the vector in order is more efficient than separate loops that read the vector with stride 2.

I also added parallelization.  This is self explanatory except maybe for the thread limit.  Because the function recurses I found it needed a limit to stop from crashing and also it could be tuned.  I am on M1 Mac with 10 cores and 8 high performance cores.  16 or 32 seemed to give the best results.

The benchmark output time goes from 0.065 -> 0.0054 seconds based on these changes.